### PR TITLE
V0.8.0/yoda/dev 모든 수집 DAG 데이터 클렌징 기능 추가

### DIFF
--- a/dags/IMDB/get_IMDB_academy.py
+++ b/dags/IMDB/get_IMDB_academy.py
@@ -27,6 +27,7 @@ def send_req(event, exe_year, base_url):
 	command = ["curl", curl_url]
 	subprocess.run(command)
 
+
 start_task = EmptyOperator(
 	task_id = 'start_academy_data_task',
 	dag = dag)
@@ -43,6 +44,11 @@ check_datas = PythonOperator(
 	python_callable = send_req,
 	op_args =['academy','{{next_execution_date.strftime("%Y")}}',f'http://{SERVER_API}/check/imdb'],
 	dag = dag)
+
+erase_datas = PythonOperator(
+	task_id = 'delete_acadmey_datas',
+	python_callable= send_req,
+	op_args=['academy', '{{next_execution_date.strftime("%Y")}}', f'http://{SERVER_API}/blob/imdb'])
 
 end_task = EmptyOperator(
 	task_id = 'finish_academy_data_task',

--- a/dags/IMDB/get_IMDB_academy.py
+++ b/dags/IMDB/get_IMDB_academy.py
@@ -45,10 +45,10 @@ check_datas = PythonOperator(
 	op_args =['academy','{{next_execution_date.strftime("%Y")}}',f'http://{SERVER_API}/check/imdb'],
 	dag = dag)
 
-erase_datas = PythonOperator(
+cleansing_data = PythonOperator(
 	task_id = 'delete_acadmey_datas',
 	python_callable= send_req,
-	op_args=['academy', '{{next_execution_date.strftime("%Y")}}', f'http://{SERVER_API}/blob/imdb'])
+	op_args=['academy', '{{next_execution_date.strftime("%Y")}}', f'http://{SERVER_API}/cleansing/imdb'])
 
 end_task = EmptyOperator(
 	task_id = 'finish_academy_data_task',

--- a/dags/IMDB/get_IMDB_busan.py
+++ b/dags/IMDB/get_IMDB_busan.py
@@ -46,7 +46,7 @@ def check_logic(event, year) :
 
 #데이터 삭제 url 생성
 def erase_datas(event, year):
-    api_url = f"http://{SERVER_API}/blob/imdb?event={event}&year={year}"
+    api_url = f"http://{SERVER_API}/cleansing/imdb?event={event}&year={year}"
     response = requests.get(api_url).json()
     
 

--- a/dags/IMDB/get_IMDB_busan.py
+++ b/dags/IMDB/get_IMDB_busan.py
@@ -43,6 +43,11 @@ def check_logic(event, year) :
     
     else:
         return "DONE"
+
+#데이터 삭제 url 생성
+def erase_datas(event, year):
+    api_url = f"http://{SERVER_API}/blob/imdb?event={event}&year={year}"
+    response = requests.get(api_url).json()
     
 
 # Operator 정의
@@ -60,6 +65,12 @@ branching = BranchPythonOperator(task_id='Check.logic',
                                  dag=dag)
 
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
+
+cleansing_data = PythonOperator(task_id = "delete.IMDB.busan_datas",
+                                python_callable=erase_datas,
+                                op_kwargs={"event": "busan", "year": "{{next_execution_date.in_timezone('Asia/Seoul').strftime('%Y')}}"},
+                                dag = dag)
+
 done = EmptyOperator(task_id = 'DONE', dag = dag)
     
 # Operator 배치

--- a/dags/IMDB/get_IMDB_cannes.py
+++ b/dags/IMDB/get_IMDB_cannes.py
@@ -46,7 +46,7 @@ def check_logic(event, year):
         return "DONE"
 
 def erase_datas(event, year):
-    api_url = f"http://{SERVER_API}/blob/imdb?event={event}&year={year}"
+    api_url = f"http://{SERVER_API}/cleansing/imdb?event={event}&year={year}"
     response = requests.get(api_url).json()
 
 # Operator 정의

--- a/dags/IMDB/get_IMDB_cannes.py
+++ b/dags/IMDB/get_IMDB_cannes.py
@@ -44,7 +44,10 @@ def check_logic(event, year):
     
     else:
         return "DONE"
-    
+
+def erase_datas(event, year):
+    api_url = f"http://{SERVER_API}/blob/imdb?event={event}&year={year}"
+    response = requests.get(api_url).json()
 
 # Operator 정의
 start = EmptyOperator(task_id = 'Stark.task', dag = dag)
@@ -59,6 +62,12 @@ branching = BranchPythonOperator(task_id='Check.logic',
                                  python_callable=check_logic,
                                  op_kwargs={"event": "cannes", "year": "{{next_execution_date.in_timezone('Asia/Seoul').strftime('%Y')}}" },
                                  dag=dag)
+
+
+cleansing_data = PythonOperator(task_id = "delete.IMDB.cannes_datas",
+                                python_callable=erase_datas,
+                                op_kwargs={"event": "cannes", "year": "{{next_execution_date.in_timezone('Asia/Seoul').strftime('%Y')}}"},
+                                dag = dag)
 
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
 done = EmptyOperator(task_id = 'DONE', dag = dag)

--- a/dags/IMDB/get_IMDB_venice.py
+++ b/dags/IMDB/get_IMDB_venice.py
@@ -41,6 +41,14 @@ def send_check_curl(event, year):
     if output == "1":
         sys.exit(1)
 
+def erase_loaded_data(event, year):
+    import subprocess, sys
+    base_url = f"http://{SERVER_API}/cleansing/imdb"
+    curl_url = f"{base_url}?event='{event}'&year='{year}'"
+    command = f"curl '{curl_url}'"
+    output = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    print(output)
+
 start = EmptyOperator(
     task_id = 'start_task',
     dag = dag)
@@ -55,6 +63,13 @@ load_data = PythonOperator(
 check_data = PythonOperator(
     task_id = 'check_IMDB_venice',
     python_callable=send_check_curl,
+    op_kwargs={"event":"venice",
+               "year":year_str},
+    dag=dag)
+
+cleansing_data = PythonOperator(
+    task_id = 'delete.IMDB.venice.datas',
+    python_callable=erase_loaded_data,
     op_kwargs={"event":"venice",
                "year":year_str},
     dag=dag)

--- a/dags/KOBIS/get_KOBIS.py
+++ b/dags/KOBIS/get_KOBIS.py
@@ -71,6 +71,20 @@ def send_check_curl():
 	if output == "1":
 		sys.exit(1)
 
+def deleted_loaded_data(date):
+	import subprocess
+	base_url = f"http://{SERVER_API}/cleansing/kobis"
+	
+	curl_url = f"{base_url}?now_date='{date}'"
+	command = f"curl '{curl_url}'"
+
+	try:
+		output = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+		print("Curl command output:", output.stdout)
+
+	except subprocess.CalledProcessError as e:
+		print("err:", e.stderr)
+
 
 start = EmptyOperator(
     task_id = 'start_task',
@@ -95,6 +109,13 @@ check_files = PythonOperator(
 	task_id = 'check_BoxOffice_files',
 	python_callable=send_check_curl,
 	dag=dag
+	)
+
+cleansing_data = PythonOperator(
+	task_id = 'delete.KOBIS.boxOffice.datas',
+	python_callable = deleted_loaded_data,
+	op_kwargs={"date": exe_date},
+	dag = dag
 	)
 
 finish = EmptyOperator(

--- a/dags/KOBIS/get_KOBIS.py
+++ b/dags/KOBIS/get_KOBIS.py
@@ -75,6 +75,7 @@ def deleted_loaded_data(date):
 	import subprocess
 	base_url = f"http://{SERVER_API}/cleansing/kobis"
 	
+	# ex_cmd = http://192.168.90.128:4552/cleansing/kobis?now_date=2023-01-01
 	curl_url = f"{base_url}?now_date='{date}'"
 	command = f"curl '{curl_url}'"
 

--- a/dags/KOPIS/get_KOPIS.py
+++ b/dags/KOPIS/get_KOPIS.py
@@ -57,7 +57,11 @@ def get_detail(next_execution_date):
     print(f"{exe_dt}일, {len(request)}건 공연상세정보 적재 완료")
     print(request)
 
-
+def erase_loaded_data(next_execution_date):
+    exe_dt=next_execution_date.in_timezone('Asia/Seoul').strftime('%Y-%m-%d')
+    api_url = f"http://{SERVER_API}/cleansing/kopis?date={exe_dt}"
+    request = requests.get(api_url).json()
+    print(request)
 
 start = EmptyOperator(task_id = 'Stark.task', dag = dag)
 finish = EmptyOperator(task_id = 'Finish.task', trigger_rule='one_success', dag = dag)
@@ -73,6 +77,10 @@ save_detail = PythonOperator(task_id="Save.Kopis_Detail",
 branching = BranchPythonOperator(task_id='Check.logic',
                                  python_callable=check_logic,
                                  dag=dag)
+
+cleansing_data = PythonOperator(task_id = 'delete.KOPIS.performance.datas',
+                                python_callable=erase_loaded_data,
+                                dag = dag)
 
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
 done = EmptyOperator(task_id = 'DONE', dag = dag)

--- a/dags/Spotify/get_SPOTIFY.py
+++ b/dags/Spotify/get_SPOTIFY.py
@@ -69,7 +69,6 @@ def extract_moiveCode_data(execution_date):
 	return movieCode_list
 	
 def send_curl_requests(movieCode_list):
-	print(movieCode_list)
 	import subprocess
 	base_url = f"http://{SERVER_API}/spotify/movie-ost"
 
@@ -82,6 +81,16 @@ def send_curl_requests(movieCode_list):
 			print("Curl command output:", result.stdout)
 		except subprocess.CalledProcessError as e:
 			print("err:", e.stderr)
+
+def erase_loaded_data():
+	import subprocess
+	base_url = f"http://{SERVER_API}/cleansing/spotify"
+	try:
+		result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+		print("command output:", result.stdout)
+	except subprocess.CalledProcessError as e:
+		print("err:", e.stderr)
+
 
 start_task = EmptyOperator(
 	task_id = 'start_spotify_datas_task',
@@ -101,6 +110,11 @@ send_task = PythonOperator(
 	provide_context=True,
 	dag=dag
 )
+
+cleansing_data = PythonOperator(
+	task_id = 'delete.spotify.OST.datas',
+	python_callable=erase_loaded_data,
+	dag = dag)
 
 end_task = EmptyOperator(
 	task_id = 'finish_spotify_datas_task',

--- a/dags/TMDB/get_TMDB_movieCredits.py
+++ b/dags/TMDB/get_TMDB_movieCredits.py
@@ -9,6 +9,8 @@ import pendulum
 local_tz = pendulum.timezone("Asia/Seoul")
 
 SERVER_API = Variable.get("SERVER_API")
+category = 'movieCredits'
+date = "{{execution_date.add(days=182, hours=9).strftime('%Y-%m-%d')}}"
 
 default_args = {
     'owner': 'sms/v0.7.0',
@@ -22,13 +24,13 @@ dag = DAG(
     default_args=default_args,
     schedule="0 3 * * 5", ## 990703+182일~ 매주 금요일 AM 03:00 실행
     tags = ['수집','TMDB','credits'],
-    max_active_runs= 1,
-    user_defined_macros={'local_dt': lambda execution_date: execution_date.in_timezone(local_tz).strftime("%Y-%m-%d %H:%M:%S")},
+    max_active_runs= 1
 )
 
 
 # 데이터 수집 API 호출
-def get_api_data(api_url, **context):
+def get_api_data(**context):
+    api_url_get_data = f"http://{SERVER_API}/tmdb/movie-credits?date={date}"
     response = requests.get(api_url)
     # 오류 처리
     response.raise_for_status()
@@ -45,8 +47,7 @@ def get_api_data(api_url, **context):
 
     return db_counts
 
-
-# # 정합성  체크
+# 정합성  체크
 def check_logic(category, date, **context):
     # XCom에서 값을 가져옵니다.
     ti = context['ti']
@@ -63,20 +64,36 @@ def check_logic(category, date, **context):
     else:
         return 'DONE'
 
+# target_date format yyyy-mm-dd
+def erase_loaded_data(target_date):
+    import subprocess
 
-category = 'movieCredits'
-date = "{{execution_date.add(days=182, hours=9).strftime('%Y-%m-%d')}}"
-api_url_get_data = f"http://{SERVER_API}/tmdb/movie-credits?date={date}"
+    base_url = f"http://{SERVER_API}/cleansing/credit"
+    curl_url = f"{base_url}?target_date={target_date}"
+    command = ["curl", curl_url]
 
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+        print("Curl command output:", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("err:", e.stderr)
 
 start = EmptyOperator(task_id = 'Start.task', dag = dag)
-get_data = PythonOperator(task_id = "Get.TMDB_Credits_Data", python_callable=get_api_data, op_args=[api_url_get_data], dag = dag)
+get_data = PythonOperator(task_id = "Get.TMDB_Credits_Data", python_callable=get_api_data, dag = dag)
 finish = EmptyOperator(task_id = 'Finish.task', dag = dag)
 
 # start >> get_data >> finish
 
 # 정합성 체크 로직
 branching = BranchPythonOperator(task_id='Check.Integrity',python_callable=check_logic, op_args=[category, date], dag=dag)
+
+cleansing_data = PythonOperator(
+    task_id = 'delete.TMDB.movieCredits.datas',
+    python_callable=erase_loaded_data,
+    op_args=['{{next_execution_date.strftime("%Y-%m-%d")}}'],
+    dag = dag)
+
+
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
 done = EmptyOperator(task_id = 'DONE', dag = dag)
 

--- a/dags/TMDB/get_TMDB_movieDetails.py
+++ b/dags/TMDB/get_TMDB_movieDetails.py
@@ -9,6 +9,8 @@ import pendulum
 local_tz = pendulum.timezone("Asia/Seoul")
 
 SERVER_API = Variable.get("SERVER_API")
+category = 'movieDetails'
+date = "{{execution_date.add(days=182, hours=9).strftime('%Y-%m-%d')}}"
 
 default_args = {
     'owner': 'sms/v0.7.0',
@@ -22,13 +24,12 @@ dag = DAG(
     default_args=default_args,
     schedule="0 3 * * 5", ## 990703+182일~ 매주 금요일 AM 03:00 실행
     tags =["수집","TMDB","영화상세정보"],
-    max_active_runs= 1,
-    user_defined_macros={'local_dt': lambda execution_date: execution_date.in_timezone(local_tz).strftime("%Y-%m-%d %H:%M:%S")},
-)
-
+    max_active_runs= 1
+    )
 
 # 데이터 수집 API 호출
-def get_api_data(api_url, **context):
+def get_api_data(**context):
+    api_url_get_data = f"http://{SERVER_API}/tmdb/movie-details?date={date}"
     response = requests.get(api_url)
     # 오류 처리
     response.raise_for_status()
@@ -63,20 +64,35 @@ def check_logic(category, date, **context):
     else:
         return 'DONE'
 
+#target_date format yyyy-mm-dd
+def erase_loaded_data(target_date):
+    import subprocess
 
-category = 'movieDetails'
-date = "{{execution_date.add(days=182, hours=9).strftime('%Y-%m-%d')}}"
-api_url_get_data = f"http://{SERVER_API}/tmdb/movie-details?date={date}"
+    base_url = f"http://{SERVER_API}/cleansing/detail"
+    curl_url = f"{base_url}?target_date={target_date}"
+    command = ["curl", curl_url]
 
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+        print("Curl command output:", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("err:", e.stderr)
 
 start = EmptyOperator(task_id = 'Start.task', dag = dag)
-get_data = PythonOperator(task_id = "Get.TMDB_Details_Data", python_callable=get_api_data, op_args=[api_url_get_data], dag = dag)
+get_data = PythonOperator(task_id = "Get.TMDB_Details_Data", python_callable=get_api_data, dag = dag)
 finish = EmptyOperator(task_id = 'Finish.task', dag = dag)
 
 # start >> get_data >> finish
 
 # 정합성 체크 로직
 branching = BranchPythonOperator(task_id='Check.Integrity',python_callable=check_logic, op_args=[category, date], dag=dag)
+
+cleansing_data = PythonOperator(
+    task_id = 'delete.TMDB.movieDetails.datas',
+    python_callable=erase_loaded_data,
+    op_args=['{{next_execution_date.strftime("%Y-%m-%d")}}'],
+    dag = dag)
+
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
 done = EmptyOperator(task_id = 'DONE', dag = dag)
 

--- a/dags/TMDB/get_TMDB_movieImages.py
+++ b/dags/TMDB/get_TMDB_movieImages.py
@@ -9,6 +9,8 @@ import pendulum
 local_tz = pendulum.timezone("Asia/Seoul")
 
 SERVER_API = Variable.get("SERVER_API")
+category = 'movieImages'
+date = "{{execution_date.add(days=364, hours=9).strftime('%Y-%m-%d')}}"
 
 default_args = {
     'owner': 'sms/v0.7.0',
@@ -22,13 +24,13 @@ dag = DAG(
     default_args=default_args,
     schedule="0 3 * * 5", ## 990102+364일~ 매주 금요일 AM 03:00 실행
     tags= ['수집','TMDB','images'],
-    max_active_runs= 1,
-    user_defined_macros={'local_dt': lambda execution_date: execution_date.in_timezone(local_tz).strftime("%Y-%m-%d %H:%M:%S")},
+    max_active_runs= 1
 )
 
 
 # 데이터 수집 API 호출
-def get_api_data(api_url, **context):
+def get_api_data(**context):
+    api_url_get_data = f"http://{SERVER_API}/tmdb/movie-images?date={date}"
     response = requests.get(api_url)
     # 오류 처리
     response.raise_for_status()
@@ -42,7 +44,6 @@ def get_api_data(api_url, **context):
     ti = context['ti']
     ti.xcom_push(key='db_counts', value=db_counts)
     
-
     return db_counts
 
 
@@ -63,20 +64,35 @@ def check_logic(category, date, **context):
     else:
         return 'DONE'
 
+#target_date format yyyy-mm-dd
+def erase_loaded_data(target_date):
+    import subprocess
 
-category = 'movieImages'
-date = "{{execution_date.add(days=364, hours=9).strftime('%Y-%m-%d')}}"
-api_url_get_data = f"http://{SERVER_API}/tmdb/movie-images?date={date}"
+    base_url = f"http://{SERVER_API}/cleansing/images"
+    curl_url = f"{base_url}?target_date={target_date}"
+    command = ["curl", curl_url]
 
+    try:
+        result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True)
+        print("Curl command output:", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("err:", e.stderr)
 
 start = EmptyOperator(task_id = 'Start.task', dag = dag)
-get_data = PythonOperator(task_id = "Get.TMDB_Images_Data", python_callable=get_api_data, op_args=[api_url_get_data], dag = dag)
+get_data = PythonOperator(task_id = "Get.TMDB_Images_Data", python_callable=get_api_data, dag = dag)
 finish = EmptyOperator(task_id = 'Finish.task', dag = dag)
 
 # start >> get_data >> finish
 
 # 정합성 체크 로직
 branching = BranchPythonOperator(task_id='Check.Integrity',python_callable=check_logic, op_args=[category, date], dag=dag)
+
+cleansing_data = PythonOperator(
+    task_id = 'delete.TMDB.movieImages.datas',
+    python_callable=erase_loaded_data,
+    op_args=['{{next_execution_date.strftime("%Y-%m-%d")}}'],
+    dag = dag)
+
 error = EmptyOperator(task_id = 'ERROR', dag = dag)
 done = EmptyOperator(task_id = 'DONE', dag = dag)
 


### PR DESCRIPTION
v0.8.0/yoda/dev는 v0.7.0/test 에서 기존 데이터 수집 하는 모든 DAG의 데이터 클렌징 operator 가 추가되었습니다.


<h3> 요구사항 </h3>

- [x] endPoint별 명세 로직에 대비하여 데이터 클렌징 로직이 상이
- [x] TMDB DAG 필요없는 로직 및 글로벌 변수 삭제
- [x] 추후 @nayeon1107 이 진행중인 to S3 operator 와 병합 하기 위한 로직 operator 구현

---

<h3> DAG 구조 기획 </h3>

해당 버전의 로직은 다음과 같으며, 자세한 사항은 코드 확인 부탁드립니다.
```
TMDB : 날짜를 기반으로 한 해당 데이터 클렌징
Spotify : 해당 폴더 전체 데이터 클렌징
IMDB : 한해 한개의 데이터이므로, 해당 폴더 데이터 클렌징
KOBIS : 당일 execution_date를 기반으로 해당 폴더에 execution_date가 포함되어있는 파티셔닝 파일 클렌징
KOPIS : 이하 동문
```

세부적인 DAG 구조도는 다음 테스트 버전에서 명시하도록 하겠습니다.
