### PR TITLE
v0.9.0/sub/dev duckDB 갱신 dag 작성

### DIFF
--- a/dags/duckDB/duckdb_kobis.py
+++ b/dags/duckDB/duckdb_kobis.py
@@ -58,7 +58,7 @@ fail_conn = EmptyOperator(
 
 
 ssh_task = SSHOperator(
-    task_id = 'ssh_test',
+    task_id = 'load_duckdb_kobis',
     command = f"python3 {SCRIPT_PATH}/duck_create_kobis_boxoffice.py",
     ssh_hook = sshHook,
     do_xcom_push=False,

--- a/dags/duckDB/duckdb_kobis.py
+++ b/dags/duckDB/duckdb_kobis.py
@@ -24,7 +24,7 @@ dag = DAG('load_duckdb_boxOffice',
       default_args = default_args,
       max_active_runs= 1,
       tags=['duckdb','데이터 로드','boxOffice'],
-      schedule="0 3 * * *", ## 매일 AM 3:00 에 실행
+      schedule="30 1 * * *", ## 매일 AM 1:30 에 실행
       )
 
 sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)

--- a/dags/duckDB/duckdb_kobis.py
+++ b/dags/duckDB/duckdb_kobis.py
@@ -1,0 +1,74 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash import BashOperator
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.models.variable import Variable
+from airflow.models import TaskInstance
+from airflow.operators.python_operator import BranchPythonOperator
+import pendulum
+
+KST = pendulum.timezone('Asia/Seoul')
+DAGS_OWNER = Variable.get('DAGS_OWNER')
+SERVER_HOST = Variable.get('DUCKDB_SERVER_HOST')
+SCRIPT_PATH = Variable.get('DUCKDB_SCRIPT_PATH')
+
+default_args = {
+    'owner': DAGS_OWNER,
+    'depends_on_past': False,
+    'start_date':datetime(2023, 10, 1, tzinfo=KST),
+    }
+
+dag = DAG('load_duckdb_boxOffice',
+      default_args = default_args,
+      max_active_runs= 1,
+      tags=['duckdb','데이터 로드','boxOffice'],
+      schedule="0 3 * * *", ## 매일 AM 3:00 에 실행
+      )
+
+sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)
+
+def check_server():
+    import subprocess
+    cmd = ["nc", "-z", "-w", "1", SERVER_HOST, "22"]
+    response = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if response.returncode == 0:
+        return 'connection_success'
+    else:
+        return 'connection_failed'
+
+
+start_task = EmptyOperator(
+    task_id = 'start_task',
+    dag = dag)
+
+check_server_conn = BranchPythonOperator(task_id='check_server_conn',
+                                 python_callable=check_server,
+                                 dag=dag)
+
+success_conn = EmptyOperator(
+    task_id = 'connection_success',
+    dag = dag)
+
+fail_conn = EmptyOperator(
+    task_id = 'connection_failed',
+    dag = dag)
+
+
+ssh_task = SSHOperator(
+    task_id = 'ssh_test',
+    command = f"python3 {SCRIPT_PATH}/duck_create_kobis_boxoffice.py",
+    ssh_hook = sshHook,
+    do_xcom_push=False,
+    dag=dag)
+
+
+end_task = EmptyOperator(
+    task_id = 'finish_task',
+    trigger_rule='all_done',
+    dag = dag)
+
+start_task >> check_server_conn >> [success_conn, fail_conn]
+success_conn >> ssh_task >> end_task

--- a/dags/duckDB/duckdb_kopis.py
+++ b/dags/duckDB/duckdb_kopis.py
@@ -1,0 +1,74 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash import BashOperator
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.models.variable import Variable
+from airflow.models import TaskInstance
+from airflow.operators.python_operator import BranchPythonOperator
+import pendulum
+
+KST = pendulum.timezone('Asia/Seoul')
+DAGS_OWNER = Variable.get('DAGS_OWNER')
+SERVER_HOST = Variable.get('DUCKDB_SERVER_HOST')
+SCRIPT_PATH = Variable.get('DUCKDB_SCRIPT_PATH')
+
+default_args = {
+    'owner': DAGS_OWNER,
+    'depends_on_past': False,
+    'start_date':datetime(2023, 10, 1, tzinfo=KST)
+    }
+
+dag = DAG('load_duckdb_kopis',
+      default_args = default_args,
+      max_active_runs= 1,
+      tags=['duckdb','데이터 로드','kopis'],
+      schedule="0 6 * * 1", ## 매주 월요일 AM 6:00 에 실행
+      )
+
+sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)
+
+def check_server():
+    import subprocess
+    cmd = ["nc", "-z", "-w", "1", SERVER_HOST, "22"]
+    response = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if response.returncode == 0:
+        return 'connection_success'
+    else:
+        return 'connection_failed'
+
+
+start_task = EmptyOperator(
+    task_id = 'start_task',
+    dag = dag)
+
+check_server_conn = BranchPythonOperator(task_id='check_server_conn',
+                                 python_callable=check_server,
+                                 dag=dag)
+
+success_conn = EmptyOperator(
+    task_id = 'connection_success',
+    dag = dag)
+
+fail_conn = EmptyOperator(
+    task_id = 'connection_failed',
+    dag = dag)
+
+
+ssh_task = SSHOperator(
+    task_id = 'ssh_test',
+    command = f"python3 {SCRIPT_PATH}/duck_create_kopis_performance.py",
+    ssh_hook = sshHook,
+    do_xcom_push=False,
+    dag=dag)
+
+
+end_task = EmptyOperator(
+    task_id = 'finish_task',
+    trigger_rule='all_done',
+    dag = dag)
+
+start_task >> check_server_conn >> [success_conn, fail_conn]
+success_conn >> ssh_task >> end_task

--- a/dags/duckDB/duckdb_kopis.py
+++ b/dags/duckDB/duckdb_kopis.py
@@ -24,7 +24,7 @@ dag = DAG('load_duckdb_kopis',
       default_args = default_args,
       max_active_runs= 1,
       tags=['duckdb','데이터 로드','kopis'],
-      schedule="0 6 * * 1", ## 매주 월요일 AM 6:00 에 실행
+      schedule="30 2 * * 1", ## 매주 월요일 AM 2:30 에 실행
       )
 
 sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)

--- a/dags/duckDB/duckdb_kopis.py
+++ b/dags/duckDB/duckdb_kopis.py
@@ -58,7 +58,7 @@ fail_conn = EmptyOperator(
 
 
 ssh_task = SSHOperator(
-    task_id = 'ssh_test',
+    task_id = 'load_duckdb_kopis',
     command = f"python3 {SCRIPT_PATH}/duck_create_kopis_performance.py",
     ssh_hook = sshHook,
     do_xcom_push=False,

--- a/dags/duckDB/duckdb_tmdb_movie.py
+++ b/dags/duckDB/duckdb_tmdb_movie.py
@@ -58,7 +58,7 @@ fail_conn = EmptyOperator(
 
 
 ssh_task = SSHOperator(
-    task_id = 'ssh_test',
+    task_id = 'load_duckdb_tmdb_movie',
     command = f"python3 {SCRIPT_PATH}/duck_create_tmdb_movie.py",
     ssh_hook = sshHook,
     do_xcom_push=False,

--- a/dags/duckDB/duckdb_tmdb_movie.py
+++ b/dags/duckDB/duckdb_tmdb_movie.py
@@ -24,7 +24,7 @@ dag = DAG('load_duckdb_tmdb_movie',
       default_args = default_args,
       max_active_runs= 1,
       tags=['duckdb','데이터 로드','TMDB','Movie'],
-      schedule="0 5 * * 5", ## 매주 금요일 AM 05:00 실행
+      schedule="0 9 * * 5", ## 매주 금요일 AM 09:00 실행
       )
 
 sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)

--- a/dags/duckDB/duckdb_tmdb_movie.py
+++ b/dags/duckDB/duckdb_tmdb_movie.py
@@ -1,0 +1,74 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash import BashOperator
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.models.variable import Variable
+from airflow.models import TaskInstance
+from airflow.operators.python_operator import BranchPythonOperator
+import pendulum
+
+KST = pendulum.timezone('Asia/Seoul')
+DAGS_OWNER = Variable.get('DAGS_OWNER')
+SERVER_HOST = Variable.get('DUCKDB_SERVER_HOST')
+SCRIPT_PATH = Variable.get('DUCKDB_SCRIPT_PATH')
+
+default_args = {
+    'owner': DAGS_OWNER,
+    'depends_on_past': False,
+    'start_date':datetime(2023, 10, 1, tzinfo=KST)
+    }
+
+dag = DAG('load_duckdb_tmdb_movie',
+      default_args = default_args,
+      max_active_runs= 1,
+      tags=['duckdb','데이터 로드','TMDB','Movie'],
+      schedule="0 5 * * 5", ## 매주 금요일 AM 05:00 실행
+      )
+
+sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)
+
+def check_server():
+    import subprocess
+    cmd = ["nc", "-z", "-w", "1", SERVER_HOST, "22"]
+    response = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if response.returncode == 0:
+        return 'connection_success'
+    else:
+        return 'connection_failed'
+
+
+start_task = EmptyOperator(
+    task_id = 'start_task',
+    dag = dag)
+
+check_server_conn = BranchPythonOperator(task_id='check_server_conn',
+                                 python_callable=check_server,
+                                 dag=dag)
+
+success_conn = EmptyOperator(
+    task_id = 'connection_success',
+    dag = dag)
+
+fail_conn = EmptyOperator(
+    task_id = 'connection_failed',
+    dag = dag)
+
+
+ssh_task = SSHOperator(
+    task_id = 'ssh_test',
+    command = f"python3 {SCRIPT_PATH}/duck_create_tmdb_movie.py",
+    ssh_hook = sshHook,
+    do_xcom_push=False,
+    dag=dag)
+
+
+end_task = EmptyOperator(
+    task_id = 'finish_task',
+    trigger_rule='all_done',
+    dag = dag)
+
+start_task >> check_server_conn >> [success_conn, fail_conn]
+success_conn >> ssh_task >> end_task

--- a/dags/duckDB/duckdb_tmdb_people.py
+++ b/dags/duckDB/duckdb_tmdb_people.py
@@ -58,7 +58,7 @@ fail_conn = EmptyOperator(
 
 
 ssh_task = SSHOperator(
-    task_id = 'ssh_test',
+    task_id = 'load_duckdb_tmdb_people',
     command = f"python3 {SCRIPT_PATH}/duck_create_tmdb_people.py",
     ssh_hook = sshHook,
     do_xcom_push=False,

--- a/dags/duckDB/duckdb_tmdb_people.py
+++ b/dags/duckDB/duckdb_tmdb_people.py
@@ -1,0 +1,74 @@
+from airflow import DAG
+from datetime import datetime, timedelta
+from airflow.operators.bash import BashOperator
+from airflow.providers.ssh.hooks.ssh import SSHHook
+from airflow.providers.ssh.operators.ssh import SSHOperator
+from airflow.operators.empty import EmptyOperator
+from airflow.models.variable import Variable
+from airflow.models import TaskInstance
+from airflow.operators.python_operator import BranchPythonOperator
+import pendulum
+
+KST = pendulum.timezone('Asia/Seoul')
+DAGS_OWNER = Variable.get('DAGS_OWNER')
+SERVER_HOST = Variable.get('DUCKDB_SERVER_HOST')
+SCRIPT_PATH = Variable.get('DUCKDB_SCRIPT_PATH')
+
+default_args = {
+    'owner': DAGS_OWNER,
+    'depends_on_past': False,
+    'start_date':datetime(2023, 10, 1, tzinfo=KST)
+    }
+
+dag = DAG('load_duckdb_tmdb_movie',
+      default_args = default_args,
+      max_active_runs= 1,
+      tags=['duckdb','데이터 로드','TMDB','People'],
+      schedule="0 6 * * 5", ## 매주 금요일 AM 6:00 에 실행
+      )
+
+sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)
+
+def check_server():
+    import subprocess
+    cmd = ["nc", "-z", "-w", "1", SERVER_HOST, "22"]
+    response = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+
+    if response.returncode == 0:
+        return 'connection_success'
+    else:
+        return 'connection_failed'
+
+
+start_task = EmptyOperator(
+    task_id = 'start_task',
+    dag = dag)
+
+check_server_conn = BranchPythonOperator(task_id='check_server_conn',
+                                 python_callable=check_server,
+                                 dag=dag)
+
+success_conn = EmptyOperator(
+    task_id = 'connection_success',
+    dag = dag)
+
+fail_conn = EmptyOperator(
+    task_id = 'connection_failed',
+    dag = dag)
+
+
+ssh_task = SSHOperator(
+    task_id = 'ssh_test',
+    command = f"python3 {SCRIPT_PATH}/duck_create_tmdb_people.py",
+    ssh_hook = sshHook,
+    do_xcom_push=False,
+    dag=dag)
+
+
+end_task = EmptyOperator(
+    task_id = 'finish_task',
+    trigger_rule='all_done',
+    dag = dag)
+
+start_task >> check_server_conn >> [success_conn, fail_conn]
+success_conn >> ssh_task >> end_task

--- a/dags/duckDB/duckdb_tmdb_people.py
+++ b/dags/duckDB/duckdb_tmdb_people.py
@@ -24,7 +24,7 @@ dag = DAG('load_duckdb_tmdb_movie',
       default_args = default_args,
       max_active_runs= 1,
       tags=['duckdb','데이터 로드','TMDB','People'],
-      schedule="0 6 * * 5", ## 매주 금요일 AM 6:00 에 실행
+      schedule="0 11 * * 5", ## 매주 금요일 AM 11:00 에 실행
       )
 
 sshHook = SSHHook(ssh_conn_id='hooniegit', cmd_timeout=15)


### PR DESCRIPTION
v0.9.0/sub/dev 은 데이터 수집 및 가공 후 DuckDB를 갱신하는 로직입니다.

### airflow dags graph

![image](https://github.com/oppenheimer-joa/airflow/assets/95599133/46341b97-b60f-483d-97c0-be1550f5d7bd)


### 요구사항

- [x] duckDB server와 통신
- [x] 수집 및 가공 완료 후 duckDB 갱신 수행

### 임시 타임테이블
```
- kopis : 매주 월요일 AM 2:30 
- kobis : 매일 AM 1:30
- tmdb_movie :  매주 금요일 AM 9:00
- tmdb_people : 매주 금요일 AM 11:00
```